### PR TITLE
Requiring big_int has changed to just big

### DIFF
--- a/src/base58.cr
+++ b/src/base58.cr
@@ -1,5 +1,5 @@
 require "./base58/*"
-require "big_int"
+require "big"
 
 module Base58
   extend self


### PR DESCRIPTION
As of crystal 0.24 the namespace for big_int has changed to `big`